### PR TITLE
Simplify guide by removing steps

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,34 +51,6 @@ Open the `application.properties` file and add the following:
 NOTE: The properties above configure the integration to send metrics to Tanzu Observability by Wavefront using the `demo` application and the `getting-started` service.
 An application can consist of an arbitrary number of microservices.
 
-. Add the following at the top level of the `pom.xml` file:
-+
-[indent=0]
-----
-<dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>com.wavefront</groupId>
-      <artifactId>wavefront-spring-boot-bom</artifactId>
-      <version>3.0.1</version>
-      <type>pom</type>
-      <scope>import</scope>
-    </dependency>
-  </dependencies>
-</dependencyManagement>
-----
-
-. Add the following under the top level `<dependencies>` section of the `pom.xml` file:
-+
-[indent=0]
-----
-<dependency>
-  <groupId>com.wavefront</groupId>
-  <artifactId>wavefront-spring-boot-starter</artifactId>
-</dependency>
-----
-
-
 . Run the application from your IDE by invoking the `main` method of `DemoApplication`.
 You see the following:
 +

--- a/complete/build.gradle
+++ b/complete/build.gradle
@@ -12,18 +12,21 @@ repositories {
 	mavenCentral()
 }
 
-dependencyManagement {
-	imports {
-		mavenBom "com.wavefront:wavefront-spring-boot-bom:3.0.1"
-	}
+ext {
+	set('wavefrontVersion', "3.0.1")
 }
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'com.wavefront:wavefront-spring-boot-starter'
-	runtimeOnly 'io.micrometer:micrometer-registry-wavefront'
+	runtimeOnly 'com.wavefront:wavefront-spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "com.wavefront:wavefront-spring-boot-bom:${wavefrontVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/complete/pom.xml
+++ b/complete/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -15,23 +15,9 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>17</java.version>
+		<wavefront.version>3.0.1</wavefront.version>
 	</properties>
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>com.wavefront</groupId>
-				<artifactId>wavefront-spring-boot-bom</artifactId>
-				<version>3.0.1</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 	<dependencies>
-		<dependency>
-			<groupId>com.wavefront</groupId>
-			<artifactId>wavefront-spring-boot-starter</artifactId>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
@@ -42,8 +28,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-wavefront</artifactId>
+			<groupId>com.wavefront</groupId>
+			<artifactId>wavefront-spring-boot-starter</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -52,6 +38,17 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.wavefront</groupId>
+				<artifactId>wavefront-spring-boot-bom</artifactId>
+				<version>${wavefront.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/complete/src/test/java/hello/DemoApplicationTests.java
+++ b/complete/src/test/java/hello/DemoApplicationTests.java
@@ -1,16 +1,13 @@
 package hello;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(properties = "management.metrics.export.wavefront.enabled=false")
 @SpringBootTest
 class DemoApplicationTests {
 
   @Test
   void contextLoads() {
   }
-	
+
 }

--- a/initial/build.gradle
+++ b/initial/build.gradle
@@ -12,11 +12,21 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('wavefrontVersion', "3.0.1")
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	runtimeOnly 'io.micrometer:micrometer-registry-wavefront'
+	runtimeOnly 'com.wavefront:wavefront-spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+dependencyManagement {
+	imports {
+		mavenBom "com.wavefront:wavefront-spring-boot-bom:${wavefrontVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/initial/pom.xml
+++ b/initial/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -15,6 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>17</java.version>
+		<wavefront.version>3.0.1</wavefront.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -27,8 +28,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.micrometer</groupId>
-			<artifactId>micrometer-registry-wavefront</artifactId>
+			<groupId>com.wavefront</groupId>
+			<artifactId>wavefront-spring-boot-starter</artifactId>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -37,6 +38,17 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.wavefront</groupId>
+				<artifactId>wavefront-spring-boot-bom</artifactId>
+				<version>${wavefront.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/initial/src/test/java/hello/DemoApplicationTests.java
+++ b/initial/src/test/java/hello/DemoApplicationTests.java
@@ -1,11 +1,8 @@
 package hello;
 
 import org.junit.jupiter.api.Test;
-
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
 
-@TestPropertySource(properties = "management.metrics.export.wavefront.enabled=false")
 @SpringBootTest
 class DemoApplicationTests {
 


### PR DESCRIPTION
An update to Spring Initializr (https://github.com/spring-io/start.spring.io/issues/1102) now automatically generates a pom.xml and build.grade with necessary dependencies, allowing for removal of those manual steps in this guide.

I also updated `DemoApplicationTests` to match what the Initializr generates.